### PR TITLE
Add oil check page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,14 +47,14 @@ function App() {
             <Link to="/fuel/add">
               <FuelUpButton />
             </Link>
+            <Link to="/oil/add">
+              <AddOilCheckButton />
+            </Link>
             <Link to="/report">
               <ReportButton />
             </Link>
             <Link to="/cars">
               <ViewCarsButton />
-            </Link>
-            <Link to="/oil/add">
-              <AddOilCheckButton />
             </Link>
           </nav>
           <Outlet />

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Outlet, Link } from "react-router-dom";
 import { AddMileageButton } from "./components/mileage/AddMileageForm";
 import { ReportButton } from "./components/events/Report";
 import { FuelUpButton } from "./components/fuel/FuelUp";
+import { AddOilCheckButton } from "./components/oil/AddOilCheckPage";
 import Breadcrumb from "./components/breadcrumb/Breadcrumb";
 import { ViewCarsButton } from "./components/car/ViewCarsPage";
 import { useState, useEffect } from "react";
@@ -51,6 +52,9 @@ function App() {
             </Link>
             <Link to="/cars">
               <ViewCarsButton />
+            </Link>
+            <Link to="/oil/add">
+              <AddOilCheckButton />
             </Link>
           </nav>
           <Outlet />

--- a/src/components/DBHelperFunctions.js
+++ b/src/components/DBHelperFunctions.js
@@ -66,3 +66,12 @@ export function getFuelUpEvents(carId, start, end) {
       .sortBy("timeUtc");
   }
 }
+
+export function getLastOilCheckEvent(carId, timeStamp) {
+  return db.oilChecks
+    .where(["carId", "timeUtc"])
+    .belowOrEqual([carId, timeStamp])
+    .reverse()
+    .limit(1)
+    .sortBy("timeUtc");
+}

--- a/src/components/breadcrumb/Breadcrumb.js
+++ b/src/components/breadcrumb/Breadcrumb.js
@@ -44,6 +44,7 @@ export const BreadcrumbIndicies = {
   mileage: "mileage",
   reports: "reports",
   cars: "cars",
+  oil: "oil",
   add: "add",
   edit: "edit",
 };

--- a/src/components/car/AddCarPage.js
+++ b/src/components/car/AddCarPage.js
@@ -6,6 +6,7 @@ import { CarMakes, CarStyles } from "./CarInfo";
 import styles from "./AddCarPage.module.css";
 import sharedButton from "../SharedButton.module.css";
 import { db } from "./../../db/DB";
+import { useNavigate } from "react-router-dom";
 
 export default function AddCarPage() {
   const {
@@ -23,6 +24,7 @@ export default function AddCarPage() {
 
   const [activeCarCount, setActiveCarCount] = useState(0);
   const [redirectEnabled, setRedirect] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     db.cars
@@ -41,7 +43,7 @@ export default function AddCarPage() {
       // set it to true if this is your first car
       isActive: (activeCarCount === 0).toString(),
     };
-    console.log({ car });
+    console.debug({ car });
 
     if (activeCarCount === 0) {
       setActiveCarCount(1);
@@ -55,8 +57,7 @@ export default function AddCarPage() {
           setActiveCarCount(1);
         }
         setRedirect(true);
-        // we want to route back to the car listings
-        window.location.replace("/cars");
+        navigate("/");
       })
       .catch((error) => {
         console.warn(`Failed to write to the browser db: ${error}`);
@@ -99,7 +100,11 @@ export default function AddCarPage() {
         ]}
       />
       {redirectEnabled ? (
-        <>The new car has been created, redirecting back to the car listings</>
+        <>
+          <p>
+            The new car has been created, redirecting back to the car listings
+          </p>
+        </>
       ) : (
         <form className={styles.carForm} onSubmit={handleSubmit(addCar)}>
           <label htmlFor="name">Name: </label>

--- a/src/components/events/FuelRreport.js
+++ b/src/components/events/FuelRreport.js
@@ -2,12 +2,14 @@ export default function FuelReport({ events }) {
   return (
     <>
       <h2>Fuel</h2>
-      <div>{events.length} fuel events were found!</div>
-      <div>
-        {events.map((event, index) => (
-          <FuelEvent key={index} event={event} />
-        ))}
-      </div>
+      <details>
+        <summary>{events.length} fuel events were found!</summary>
+        <div>
+          {events.map((event, index) => (
+            <FuelEvent key={index} event={event} />
+          ))}
+        </div>
+      </details>
     </>
   );
 }

--- a/src/components/oil/AddOilCheckPage.js
+++ b/src/components/oil/AddOilCheckPage.js
@@ -8,6 +8,9 @@ import dayjs from "dayjs";
 import { useState, useEffect } from "react";
 import Breadcrumb, { BreadcrumbIndicies } from "../breadcrumb/Breadcrumb";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTint } from "@fortawesome/free-solid-svg-icons";
+
 export default function AddOilCheckPage() {
   const [oilLevel, setOilLevel] = useState(0);
   const [oilPercentage, setOilPercentage] = useState(150);
@@ -225,8 +228,18 @@ function getColour(opacity) {
 export function AddOilCheckButton() {
   return (
     <div className={[sharedStyles.cardButton].join(" ")}>
-      <div className={[sharedStyles.animatedCard].join(" ")}>
-        <div className={[sharedStyles.animatedCardText].join(" ")}>
+      <div
+        className={[
+          sharedStyles.animatedCard,
+          styles.animatedOilCheckButton,
+        ].join(" ")}
+      >
+        <div className={styles.animatedDrip}>
+          <FontAwesomeIcon className={styles.oilDrip} icon={faTint} />
+        </div>
+        <div
+          className={[sharedStyles.animatedCardText, styles.cardText].join(" ")}
+        >
           Add Oil Check
         </div>
       </div>

--- a/src/components/oil/AddOilCheckPage.js
+++ b/src/components/oil/AddOilCheckPage.js
@@ -1,0 +1,68 @@
+import styles from "./AddOilCheckPage.module.css";
+import sharedStyles from "../SharedCard.module.css";
+import { useState } from "react";
+
+export default function AddOilCheckPage() {
+  const [oilLevel, setOilLevel] = useState(100);
+  const [oilColour, setOilColour] = useState(0);
+
+  const changeOilColour = (event) => {
+    console.log(event.target.value);
+    setOilColour(event.target.value);
+  };
+
+  const changeOilLevel = (event) => {
+    setOilLevel(event.target.value);
+  };
+
+  return (
+    <>
+      <div>
+        {oilLevel} {oilColour}
+      </div>
+      <div>
+        <input
+          className={styles.oilLeveller}
+          type="range"
+          onChange={changeOilLevel}
+          value={oilLevel}
+          min="0"
+          max="150"
+        />
+      </div>
+      <div>
+        <input
+          type="range"
+          onChange={changeOilColour}
+          value={oilColour}
+          lists={styles.tickmarks}
+        />
+        <datalist id={styles.tickmarks}>
+          <option value="0" label="clear"></option>
+          <option value="10"></option>
+          <option value="20"></option>
+          <option value="30"></option>
+          <option value="40"></option>
+          <option value="50"></option>
+          <option value="60"></option>
+          <option value="70"></option>
+          <option value="80"></option>
+          <option value="90"></option>
+          <option value="100" label="foggy"></option>
+        </datalist>
+      </div>
+    </>
+  );
+}
+
+export function AddOilCheckButton() {
+  return (
+    <div className={[sharedStyles.cardButton].join(" ")}>
+      <div className={[sharedStyles.animatedCard].join(" ")}>
+        <div className={[sharedStyles.animatedCardText].join(" ")}>
+          Add Oil Check
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/oil/AddOilCheckPage.js
+++ b/src/components/oil/AddOilCheckPage.js
@@ -1,58 +1,169 @@
+import { db } from "./../../db/DB";
 import styles from "./AddOilCheckPage.module.css";
 import sharedStyles from "../SharedCard.module.css";
+import sharedButtons from "../SharedButton.module.css";
+
 import { useState } from "react";
+import Breadcrumb, { BreadcrumbIndicies } from "../breadcrumb/Breadcrumb";
 
 export default function AddOilCheckPage() {
-  const [oilLevel, setOilLevel] = useState(100);
-  const [oilColour, setOilColour] = useState(0);
+  const [oilLevel, setOilLevel] = useState(0);
+  const [oilPercentage, setOilPercentage] = useState(150);
+  const [oilColour, setOilColour] = useState(20);
+  const [oilText, setOilText] = useState(determineOpacityValue(oilColour));
+
+  const id = "container";
+
+  const currentStyle = {
+    top: oilLevel.toFixed(2) + "px",
+    opacity: oilColour + "%",
+    backgroundColor: getColour(oilColour),
+  };
+
+  console.log({ currentStyle });
 
   const changeOilColour = (event) => {
-    console.log(event.target.value);
-    setOilColour(event.target.value);
+    let oilOpacity = event.target.value;
+
+    console.log({ oilOpacity });
+    setOilColour(oilOpacity);
+    setOilText(determineOpacityValue(oilOpacity));
   };
 
   const changeOilLevel = (event) => {
-    setOilLevel(event.target.value);
+    // the oil level must range from 0 to 150%
+    const container = document.getElementById(id);
+    const computedYCoord =
+      event.clientY - container.offsetParent.offsetTop - container.offsetTop;
+    const computedPercentage =
+      (1 - computedYCoord / container.offsetHeight) * 150;
+    console.log({
+      computedPercentage,
+      computedYCoord,
+      clientY: event.clientY,
+      offsetTop: container.offsetTop,
+    });
+    setOilLevel(computedYCoord);
+    setOilPercentage(computedPercentage);
   };
+
+  const handleSave = () => {};
 
   return (
     <>
-      <div>
-        {oilLevel} {oilColour}
+      <Breadcrumb
+        uriSegments={[
+          BreadcrumbIndicies.home,
+          BreadcrumbIndicies.oil,
+          BreadcrumbIndicies.add,
+        ]}
+      />
+      <div className={styles.container}>
+        <div
+          id={id}
+          className={[styles.fuelTankContainer].join(" ")}
+          onClick={changeOilLevel}
+        >
+          <div className={styles.gasLevel} style={currentStyle}></div>
+          <div
+            className={[styles.hundredFiftyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.hundredFortyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.hundredFortyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.hundredThirtyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.hundredTwentyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.hundredTenMark, styles.mainorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.hundredMark, styles.majorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.ninetyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.eightyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.seventyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div className={[styles.sixtyMark, styles.minorMark].join(" ")}></div>
+          <div className={[styles.fiftyMark, styles.majorMark].join(" ")}></div>
+          <div
+            className={[styles.fourtyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.thirtyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div
+            className={[styles.twentyMark, styles.minorMark].join(" ")}
+          ></div>
+          <div className={[styles.tenMark, styles.minorMark].join(" ")}></div>
+          <div className={[styles.zeroMark, styles.minorMark].join(" ")}></div>
+        </div>
+      </div>
+      <div className={styles.summary}>
+        <div>
+          Oil is {oilPercentage.toFixed(2)}% full and is {oilText}.{" "}
+        </div>
+        {oilColour > 80 ? (
+          <div className={styles.warning}>Your oil may need changing</div>
+        ) : (
+          ""
+        )}
       </div>
       <div>
-        <input
-          className={styles.oilLeveller}
-          type="range"
-          onChange={changeOilLevel}
-          value={oilLevel}
-          min="0"
-          max="150"
-        />
-      </div>
-      <div>
+        <h2>Oil colour</h2>
         <input
           type="range"
           onChange={changeOilColour}
           value={oilColour}
           lists={styles.tickmarks}
+          className={styles.oilColourSlider}
+          min="20"
+          max="100"
+          step="10"
         />
-        <datalist id={styles.tickmarks}>
-          <option value="0" label="clear"></option>
-          <option value="10"></option>
-          <option value="20"></option>
-          <option value="30"></option>
-          <option value="40"></option>
-          <option value="50"></option>
-          <option value="60"></option>
-          <option value="70"></option>
-          <option value="80"></option>
-          <option value="90"></option>
-          <option value="100" label="foggy"></option>
-        </datalist>
       </div>
+      <button
+        className={[sharedButtons.button, styles.oilCheckButton].join(" ")}
+        onClick={handleSave}
+      >
+        Add Oil Check
+      </button>
     </>
   );
+}
+
+// from here: https://carbuyerlabs.com/the-color-of-your-engine-oil-says-a-lot-so-pay-attention/
+function determineOpacityValue(opacity) {
+  if (opacity < 30) {
+    return "clean";
+  } else if (opacity < 70) {
+    return "normal";
+  } else {
+    return "dark";
+  }
+}
+
+function getColour(opacity) {
+  if (opacity < 30) {
+    return "lightgoldenrod";
+  } else if (opacity < 70) {
+    return "goldenrod";
+  } else if (opacity < 90) {
+    return "maroon";
+  } else {
+    return "black";
+  }
 }
 
 export function AddOilCheckButton() {

--- a/src/components/oil/AddOilCheckPage.module.css
+++ b/src/components/oil/AddOilCheckPage.module.css
@@ -59,7 +59,7 @@
 }
 
 .resetOilCheckButton {
-    width: 100%;
+  width: 100%;
 }
 
 .oilColourSlider {
@@ -73,4 +73,44 @@
 
 .summary {
   padding: 1em;
+}
+
+.animatedOilCheckButton {
+  background-color: gray;
+}
+
+.animatedOilCheckButton:hover,
+.animatedOilCheckButton:active {
+  background-color: #80a1c3;
+}
+
+.oilDrip {
+  color: gold;
+  filter: grayscale(1);
+
+  animation: changeColours 4s infinite alternate ease-in-out;
+  animation-play-state: paused;
+  transition: all 0.5s;
+}
+
+.animatedOilCheckButton:hover .oilDrip,
+.animatedOilCheckButton:active .oilDrip {
+  filter: none;
+  color: gold;
+  animation-play-state: running;
+}
+
+.animatedDrip {
+  position: absolute;
+  font-size: 8vmin;
+  right: 15vmin;
+}
+
+@keyframes changeColours {
+  0% {
+    color: lightgoldenrodyellow;
+  }
+  100% {
+    color: maroon;
+  }
 }

--- a/src/components/oil/AddOilCheckPage.module.css
+++ b/src/components/oil/AddOilCheckPage.module.css
@@ -44,6 +44,7 @@
   top: 20px;
   background-color: goldenrod;
   z-index: -1;
+  transition: background 0.2s;
 }
 
 .container {
@@ -55,6 +56,10 @@
   width: 100%;
   background-color: rgb(37, 147, 238);
   color: white;
+}
+
+.resetOilCheckButton {
+    width: 100%;
 }
 
 .oilColourSlider {

--- a/src/components/oil/AddOilCheckPage.module.css
+++ b/src/components/oil/AddOilCheckPage.module.css
@@ -1,11 +1,71 @@
-#tickmarks {
+.fuelTankContainer {
+  width: 14vmin;
+  height: 92vmin;
+  border: solid black;
+  border-top: none;
+  border-radius: 0 0 5px 5px;
+  position: absolute;
+  overflow: hidden;
+}
+
+.minorMark {
+  height: 5.6vmin;
+  width: 2vmin;
+  border-bottom: solid black;
+}
+
+.minorMark:nth-child(18) {
+  border: none;
+}
+
+.majorMark {
+  height: 5.6vmin;
+  width: 4vmin;
+  border-bottom: solid black;
+}
+
+.hundredMark {
   display: flex;
 }
 
-.oilLeveller {
-  width: 150px;
-  height: 20px;
-  margin: 0;
-  transform-origin: 75px 75px;
-  transform: rotate(-90deg);
+.hundredMark:after {
+  content: "full";
+  align-self: end;
+}
+
+.zeroMark:after {
+  content: "empty";
+}
+
+.gasLevel {
+  position: absolute;
+  width: 14vmin;
+  height: 100vmin;
+  top: 20px;
+  background-color: goldenrod;
+  z-index: -1;
+}
+
+.container {
+  height: 95vmin;
+  padding-left: 10vmin;
+}
+
+.oilCheckButton {
+  width: 100%;
+  background-color: rgb(37, 147, 238);
+  color: white;
+}
+
+.oilColourSlider {
+  width: 100%;
+}
+
+.warning {
+  background-color: yellow;
+  height: 2em;
+}
+
+.summary {
+  padding: 1em;
 }

--- a/src/components/oil/AddOilCheckPage.module.css
+++ b/src/components/oil/AddOilCheckPage.module.css
@@ -1,0 +1,11 @@
+#tickmarks {
+  display: flex;
+}
+
+.oilLeveller {
+  width: 150px;
+  height: 20px;
+  margin: 0;
+  transform-origin: 75px 75px;
+  transform: rotate(-90deg);
+}

--- a/src/db/DB.js
+++ b/src/db/DB.js
@@ -2,12 +2,13 @@ import Dexie from "dexie";
 
 export const db = new Dexie("fit_car");
 
-db.version(3).stores({
+db.version(5).stores({
   mileage: "++id, [carId+timeUtc], carId, mileage, timeUtc",
   cars: "++id, name, make, style, maxTank, isActive",
   fuelFillUps:
     "++id, [carId+timeUtc], carId, price, fuelType, previousTank, currentTank, timeUtc",
   events: "++id, carId, type, eventId, timeUtc",
+  oilChecks: "++id, [carId+timeUtc], carId, timeUtc, percentage, opacity, note",
 });
 // injecting test data
 // db.cars.add({

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import FuelUp from "./components/fuel/FuelUp";
 import EditCarPage from "./components/car/EditCarPage";
 import ViewCarsPage from "./components/car/ViewCarsPage";
 import AddCarPage from "./components/car/AddCarPage";
+import AddOilCheckPage from "./components/oil/AddOilCheckPage";
 
 const rootElement = document.getElementById("root");
 
@@ -19,13 +20,14 @@ ReactDOM.render(
   <BrowserRouter basename={process.env.PUBLIC_URL}>
     <Routes>
       <Route path="/" element={<App />}></Route>
-      <Route path="mileage/add" element={<AddNewMileage/>} />
-      <Route path="mileage" element={<ReadMileage/>} />
-      <Route path="fuel/add" element={<FuelUp/>} />
+      <Route path="mileage/add" element={<AddNewMileage />} />
+      <Route path="mileage" element={<ReadMileage />} />
+      <Route path="fuel/add" element={<FuelUp />} />
       <Route path="cars" element={<ViewCarsPage />} />
-      <Route path="cars/add" element={<AddCarPage/>} />
+      <Route path="cars/add" element={<AddCarPage />} />
       <Route path="cars/:carId/edit" element={<EditCarPage />} />
-      <Route path="report" element={<Report/>} />
+      <Route path="report" element={<Report />} />
+      <Route path="oil/add" element={<AddOilCheckPage />} />
     </Routes>
   </BrowserRouter>,
   rootElement


### PR DESCRIPTION
## What did I add in this PR?

Support for oil checks.

There should now be an oilcheck table with the indexes of:

- id
- carId + timeUtc
- timeUtc
- percentage - this is how full the dipstick is recording, this is measured from 0 to 150, where you can have more than 100% of the engine oil in the car
- opacity - how light or dark the oil is, this is measured from 20 to 90 where 20 is fairly light, and 90 is dark
- note - not really sure if this is needed really


## Bug fixes

Fixed up a thing where the routing did not route properly after creating a car